### PR TITLE
解决加载第三方字体文件时，内容存在，可是名称无法获取导致加载本地或相似的字体文件，转换文件字体内容异常

### DIFF
--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/AWTMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/AWTMaker.java
@@ -419,7 +419,7 @@ public abstract class AWTMaker {
         List<Number> fontMatrix = null;
 
         if (typeFont == null) {
-            logger.info("无法加载字体ID：" + textObject.getFont());
+            logger.warn("无法加载字体ID：" + textObject.getFont());
 //            typeFont = FontLoader.getInstance().loadDefaultFont();
             return;
         } else {
@@ -442,9 +442,7 @@ public abstract class AWTMaker {
                     transform.setCodePosition(0);
                 }
             });
-            transforms.sort((t1, t2) -> {
-                return t1.getCodePosition() - t2.getCodePosition();
-            });
+            transforms.sort(Comparator.comparingInt(CT_CGTransform::getCodePosition));
         }
         for (TextCode textCode : textObject.getTextCodes()) {
             int deltaOffset = -1;
@@ -497,7 +495,6 @@ public abstract class AWTMaker {
                         }
                         logger.debug(String.format("字形索引 <%s> DeltaX:%s DeltaY:%s", glyph, x, y));
                         try {
-//                            typeFont.getGlyph().getGlyphs();
                             GlyphData glyphData = typeFont.getGlyph().getGlyph(glyph);
                             if (glyphData != null) {
                                 Shape shape = glyphData.getPath();
@@ -514,8 +511,9 @@ public abstract class AWTMaker {
                     } else {
                         transPoint++;
                     }
-                    globalPoint += (transform.getCodeCount() != null ? transform.getCodeCount() : glyphs.size());
-                    j += (transform.getCodeCount() != null ? transform.getCodeCount() : glyphs.size());
+                    int codeCount = (transform.getCodeCount() != null ? transform.getCodeCount() : glyphs.size());
+                    globalPoint += codeCount;
+                    j += codeCount;
                 }
 
             }
@@ -547,7 +545,9 @@ public abstract class AWTMaker {
     }
 
     private void renderChar(Graphics2D graphics, Shape shape, Matrix m, Color stroke, Color fill) {
-        if (shape == null) return;
+        if (shape == null) {
+            return;
+        }
         graphics.setClip(null);
         graphics.setTransform(MatrixUtils.createAffineTransform(m));
 //        graphics.setStroke(new BasicStroke(0.1f));
@@ -698,7 +698,6 @@ public abstract class AWTMaker {
         if (ctColor == null) return null;
         ST_Array array = ctColor.getValue();
 
-
         OFDColorSpaceType type = OFDColorSpaceType.RGB;
         ST_RefID refID = ctColor.getColorSpace();
         CT_ColorSpace ctColorSpace = null;
@@ -746,7 +745,6 @@ public abstract class AWTMaker {
         List<Double> arr = new ArrayList<>();
 
         int i = 0;
-        int counter = 0;
         while (i < array.size()) {
             String current = array.getArray().get(i);
             if ("g".equals(current)) {
@@ -754,13 +752,11 @@ public abstract class AWTMaker {
                 Double delta = Double.valueOf(array.getArray().get(i + 2));
                 for (int j = 1; j <= num; j++) {
                     arr.add(delta);
-                    counter++;
                 }
                 i += 3;
             } else {
                 Double delta = Double.valueOf(current);
                 arr.add(delta);
-                counter++;
                 i++;
             }
 

--- a/ofdrw-converter/src/main/java/org/ofdrw/converter/ImageMaker.java
+++ b/ofdrw-converter/src/main/java/org/ofdrw/converter/ImageMaker.java
@@ -1,7 +1,8 @@
 package org.ofdrw.converter;
 
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 
 import org.ofdrw.converter.utils.CommonUtil;
 import org.ofdrw.core.basicType.ST_Box;
@@ -64,7 +65,8 @@ public class ImageMaker extends AWTMaker {
 
         BufferedImage image = createImage(pageWidthPixel, pageHeightPixel);
         Graphics2D graphics = (Graphics2D) image.getGraphics();
-
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL,RenderingHints.VALUE_STROKE_DEFAULT);
         writePage(graphics, pageInfo, null);
 
         return image;
@@ -78,5 +80,34 @@ public class ImageMaker extends AWTMaker {
      */
     private BufferedImage createImage(int pageWidthPixel, int pageHeightPixel) {
         return ImageUtils.createImage(pageWidthPixel, pageHeightPixel, isStamp);
+    }
+
+    /**
+     * 渲染OFD页面为图片字节数组
+     *
+     * @param pageIndex 页码，从0起
+     * @param type 图片类型，jpg,png,...
+     * @return 渲染完成的图片字节数组
+     */
+    public byte[] makePage(int pageIndex, String type) throws IOException {
+        if (pageIndex < 0 || pageIndex >= pages.size()) {
+            throw new GeneralConvertException(String.format("%s 不是有效索引", pageIndex));
+        }
+        PageInfo pageInfo = pages.get(pageIndex);
+        ST_Box pageBox = pageInfo.getSize();
+
+        // PPM 转 像素
+        int pageWidthPixel = (int) Math.round(ppm * pageBox.getWidth());
+        int pageHeightPixel = (int) Math.round(ppm * pageBox.getHeight());
+
+        BufferedImage image = createImage(pageWidthPixel, pageHeightPixel);
+        Graphics2D graphics = (Graphics2D) image.getGraphics();
+        //消除文字锯齿
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        //消除画图锯
+        graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL,RenderingHints.VALUE_STROKE_DEFAULT);
+        writePage(graphics, pageInfo, null);
+
+        return ImageUtils.toBytes(image, type);
     }
 }

--- a/ofdrw-converter/src/test/java/OFD2IMGTest.java
+++ b/ofdrw-converter/src/test/java/OFD2IMGTest.java
@@ -1,6 +1,7 @@
 import org.junit.jupiter.api.Test;
 import org.ofdrw.converter.FontLoader;
 import org.ofdrw.converter.ImageMaker;
+import org.ofdrw.converter.utils.CommonUtil;
 import org.ofdrw.reader.DLOFDReader;
 import org.ofdrw.reader.OFDReader;
 
@@ -33,7 +34,7 @@ public class OFD2IMGTest {
 //        toPng("src/test/resources/z.ofd", "target/z.ofd");
 //        toPng("src/test/resources/不规范资源路径.ofd", "target/不规范资源路径.ofd");
 //        toPng("src/test/resources/V4RideRight.ofd", "target/V4RideRight.ofd");
-        toPng("src/test/resources/发票示例.ofd", "target/发票示例.ofd");
+        toPng("C:\\Users\\Administrator\\Desktop\\ofd\\取水许可证 示例文件.ofd", "target/取水许可证 示例文件.ofd");
 
         System.out.printf(">> 总计花费: %dms\n", System.currentTimeMillis() - start);
     }
@@ -43,15 +44,13 @@ public class OFD2IMGTest {
         Path src = Paths.get(filename);
 
         try(OFDReader reader = new OFDReader(src);){
-            ImageMaker imageMaker = new ImageMaker(reader, 15);
+            ImageMaker imageMaker = new ImageMaker(reader, CommonUtil.dpiToPpm(150));
             imageMaker.config.setDrawBoundary(false);
             for (int i = 0; i < imageMaker.pageSize(); i++) {
                 BufferedImage image = imageMaker.makePage(i);
-                Path dist = Paths.get(dirPath, i + ".png");
-                ImageIO.write(image, "PNG", dist.toFile());
+                Path dist = Paths.get(dirPath, i + ".JPG");
+                ImageIO.write(image, "JPG", dist.toFile());
             }
         }
-
     }
-
 }

--- a/ofdrw-core/src/main/java/org/ofdrw/core/basicStructure/doc/CT_CommonData.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/basicStructure/doc/CT_CommonData.java
@@ -189,4 +189,19 @@ public class CT_CommonData extends OFDElement {
     public ST_RefID getDefaultCS() {
         return ST_RefID.getInstance(this.getOFDElementText("DefaultCS"));
     }
+
+    /**
+     * 获取 公共资源序列 列表
+     * @return 公共资源序列路径列表
+     */
+    public List<ST_Loc> getPublicResList() {
+        List<ST_Loc> st_locs = new ArrayList<>();
+        List<Element> elements = this.proxy.elements();
+        for (Element element : elements) {
+            if ("PublicRes".equals(element.getName())) {
+                st_locs.add(ST_Loc.getInstance(element));
+            }
+        }
+        return st_locs;
+    }
 }

--- a/ofdrw-reader/src/main/java/org/ofdrw/reader/ResourceManage.java
+++ b/ofdrw-reader/src/main/java/org/ofdrw/reader/ResourceManage.java
@@ -440,11 +440,22 @@ public class ResourceManage {
 
             commonData = new CT_CommonData((Element) document.getCommonData().clone());
             // 公共资源序列（PublicRes）
-            loadResFile(rl, commonData.getPublicRes());
+            loadResFile(rl, commonData.getPublicResList());
             // 文档资源序列（DocumentRes）
             loadResFile(rl, commonData.getDocumentRes());
         } finally {
             rl.restore();
+        }
+    }
+
+    /**
+     * 加载资源文件列表中描述的资源对象
+     * @param r1 资源加载器
+     * @param resLocList 资源文件列表位置
+     */
+    private void loadResFile(ResourceLocator r1, List<ST_Loc> resLocList){
+        for(ST_Loc stLoc : resLocList){
+            this.loadResFile(r1, stLoc);
         }
     }
 


### PR DESCRIPTION
解决加载第三方字体文件时，内容存在，可是名称无法获取导致加载本地或相似的字体文件，转换文件字体内容异常